### PR TITLE
Disable automatic report refresh

### DIFF
--- a/test_YBS_CONTROL.py
+++ b/test_YBS_CONTROL.py
@@ -188,7 +188,7 @@ class YBSControlTests(unittest.TestCase):
             patch.object(OrderScraperApp, "_build_settings_tab"), \
             patch.object(OrderScraperApp, "_build_date_range_tab"), \
             patch.object(OrderScraperApp, "schedule_order_scrape"), \
-            patch.object(OrderScraperApp, "schedule_daily_export"):
+            patch.object(OrderScraperApp, "schedule_daily_export") as mock_schedule_export:
 
             mock_ctk.StringVar.side_effect = lambda value="": SimpleVar(value)
             tabview_mock = MagicMock()
@@ -208,6 +208,7 @@ class YBSControlTests(unittest.TestCase):
             mock_connect.assert_called_with(expected)
             self.assertEqual(app.db_path_var.get(), expected)
             self.assertEqual(app.last_db_dir, str(DEFAULT_DB_DIR))
+            mock_schedule_export.assert_not_called()
 
     @patch("ui.order_app.filedialog.askdirectory", return_value="/exports")
     def test_browse_export_path_uses_last_directory(self, mock_dialog):

--- a/ui/order_app.py
+++ b/ui/order_app.py
@@ -133,7 +133,6 @@ class OrderScraperApp:
         self._build_settings_tab()
         self._build_date_range_tab()
         self.schedule_order_scrape()
-        self.schedule_daily_export()
 
     # Placeholder methods for patched-out GUI builders
     def _build_settings_tab(self):


### PR DESCRIPTION
## Summary
- Stop automatically scheduling daily report exports so only the database refresh runs by default
- Update tests to assert daily export scheduling is disabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6511cdfbc832d86ddd8b667f2e879