### PR TITLE
Add placeholder theme module to fix import error

### DIFF
--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,0 +1,7 @@
+def configure() -> None:
+    """Dummy theme configuration placeholder."""
+    # In the production environment this module would configure the
+    # CustomTkinter theme.  For the test environment a no-op keeps
+    # imports lightweight and avoids requiring the actual GUI theme
+    # files.
+    pass


### PR DESCRIPTION
## Summary
- Add minimal `ui.theme` module with `configure` placeholder to satisfy imports in `YBS_CONTROL`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6521c1e60832db70d8e96be33f914